### PR TITLE
Allow a fuel amount = 0

### DIFF
--- a/src/SwitchableResource.cs
+++ b/src/SwitchableResource.cs
@@ -80,7 +80,7 @@ namespace SimpleFuelSwitch
                 throw new ArgumentException("No such resource '" + name + "' exists");
             }
             amount = GetRequiredDouble(node, AMOUNT_TAG);
-            if (amount <= 0)
+            if (amount < 0)
             {
                 throw new ArgumentException(AMOUNT_TAG + " must be a positive number");
             }

--- a/src/SwitchableResource.cs
+++ b/src/SwitchableResource.cs
@@ -85,7 +85,7 @@ namespace SimpleFuelSwitch
                 throw new ArgumentException(AMOUNT_TAG + " must be a positive number");
             }
             maxAmount = GetRequiredDouble(node, MAX_AMOUNT_TAG);
-            if (maxAmount > amount)
+            if (maxAmount => amount)
             {
                 throw new ArgumentException(MAX_AMOUNT_TAG + " must be greater than or equal to " + AMOUNT_TAG);
             }

--- a/src/SwitchableResource.cs
+++ b/src/SwitchableResource.cs
@@ -85,7 +85,7 @@ namespace SimpleFuelSwitch
                 throw new ArgumentException(AMOUNT_TAG + " must be a positive number");
             }
             maxAmount = GetRequiredDouble(node, MAX_AMOUNT_TAG);
-            if (maxAmount => amount)
+            if (maxAmount < amount)
             {
                 throw new ArgumentException(MAX_AMOUNT_TAG + " must be greater than or equal to " + AMOUNT_TAG);
             }

--- a/src/SwitchableResource.cs
+++ b/src/SwitchableResource.cs
@@ -85,7 +85,7 @@ namespace SimpleFuelSwitch
                 throw new ArgumentException(AMOUNT_TAG + " must be a positive number");
             }
             maxAmount = GetRequiredDouble(node, MAX_AMOUNT_TAG);
-            if (maxAmount < amount)
+            if (maxAmount > amount)
             {
                 throw new ArgumentException(MAX_AMOUNT_TAG + " must be greater than or equal to " + AMOUNT_TAG);
             }


### PR DESCRIPTION
Fixes an exception when trying to apply different fuels on wings with fuel capacity which prevented the game to launch
(Fix for [issue#1](https://github.com/KSPSnark/SimpleFuelSwitch/issues/1))